### PR TITLE
Implement GetUserAvailability types

### DIFF
--- a/src/main/php/ews/messages/FreeBusyResponse.class.php
+++ b/src/main/php/ews/messages/FreeBusyResponse.class.php
@@ -1,0 +1,5 @@
+<?php namespace ews\messages;
+
+class FreeBusyResponse extends \ews\Object {
+  
+}

--- a/src/main/php/ews/messages/FreeBusyResponseArray.class.php
+++ b/src/main/php/ews/messages/FreeBusyResponseArray.class.php
@@ -1,0 +1,5 @@
+<?php namespace ews\messages;
+
+class FreeBusyResponseArray extends \ews\ListOf {
+  
+}

--- a/src/main/php/ews/messages/FreeBusyView.class.php
+++ b/src/main/php/ews/messages/FreeBusyView.class.php
@@ -1,0 +1,5 @@
+<?php namespace ews\messages;
+
+class FreeBusyView extends \ews\Object {
+  
+}

--- a/src/main/php/ews/messages/GetUserAvailabilityRequest.class.php
+++ b/src/main/php/ews/messages/GetUserAvailabilityRequest.class.php
@@ -1,6 +1,23 @@
 <?php namespace ews\messages;
 
+use ews\types\FreeBusyViewOptions;
+
 /** @see https://msdn.microsoft.com/en-us/library/office/aa563800(v=exchg.150).aspx */
 class GetUserAvailabilityRequest extends \ews\Object {
-  
+
+  /**
+   * Creates a new "UserAvailability" request
+   *
+   * @param  ews.MailboxData[]|ews.MailboxDataArray $mailboxes
+   * @param  ews.FreeBusyViewOptions $freeBusyViewOptions
+   */
+  public function __construct($mailboxes= null, $freeBusyViewOptions= null) {
+    parent::__construct(nameof($this));
+    if ($mailboxes instanceof MailboxDataArray) {
+      $this->with($mailboxes);
+    } else if (is_array($mailboxes)) {
+      $this->with(new MailboxDataArray($mailboxes));
+    }
+    $freeBusyViewOptions && $this->with($freeBusyViewOptions);
+  }
 }

--- a/src/main/php/ews/messages/GetUserAvailabilityRequest.class.php
+++ b/src/main/php/ews/messages/GetUserAvailabilityRequest.class.php
@@ -1,0 +1,6 @@
+<?php namespace ews\messages;
+
+/** @see https://msdn.microsoft.com/en-us/library/office/aa563800(v=exchg.150).aspx */
+class GetUserAvailabilityRequest extends \ews\Object {
+  
+}

--- a/src/main/php/ews/messages/GetUserAvailabilityResponse.class.php
+++ b/src/main/php/ews/messages/GetUserAvailabilityResponse.class.php
@@ -1,0 +1,5 @@
+<?php namespace ews\messages;
+
+class GetUserAvailabilityResponse extends \ews\Object {
+  
+}

--- a/src/main/php/ews/messages/MailboxDataArray.class.php
+++ b/src/main/php/ews/messages/MailboxDataArray.class.php
@@ -1,0 +1,9 @@
+<?php namespace ews\messages;
+
+class MailboxDataArray extends \ews\ListOf {
+
+  public function __construct($mailboxes= []) {
+    parent::__construct(nameof($this));
+    $this->elements= $mailboxes;
+  }
+}

--- a/src/main/php/ews/messages/ResponseMessage.class.php
+++ b/src/main/php/ews/messages/ResponseMessage.class.php
@@ -1,0 +1,7 @@
+<?php namespace ews\messages;
+
+class ResponseMessage extends \ews\Object {
+
+  /** @return bool */
+  public function isSuccess() { return 'Success' === $this->member('ResponseClass', null); }
+}

--- a/src/main/php/ews/types/AttendeeType.class.php
+++ b/src/main/php/ews/types/AttendeeType.class.php
@@ -1,0 +1,18 @@
+<?php namespace ews\types;
+
+class AttendeeType extends \ews\Value {
+  public static $ORGANIZER, $REQUIRED, $OPTIONAL, $ROOM, $RESOURCE;
+
+  static function __static() {
+    self::$ORGANIZER= new self('Organizer');
+    self::$REQUIRED= new self('Required');
+    self::$OPTIONAL= new self('Optional');
+    self::$ROOM= new self('Room');
+    self::$RESOURCE= new self('Resource');
+  }
+
+  public function __construct($string= null) {
+    parent::__construct(nameof($this));
+    $this->string= $string;
+  }
+}

--- a/src/main/php/ews/types/CalendarEvent.class.php
+++ b/src/main/php/ews/types/CalendarEvent.class.php
@@ -1,0 +1,5 @@
+<?php namespace ews\types;
+
+class CalendarEvent extends \ews\Object {
+  
+}

--- a/src/main/php/ews/types/CalendarEventArray.class.php
+++ b/src/main/php/ews/types/CalendarEventArray.class.php
@@ -1,0 +1,5 @@
+<?php namespace ews\types;
+
+class CalendarEventArray extends \ews\ListOf {
+  
+}

--- a/src/main/php/ews/types/DaylightTime.class.php
+++ b/src/main/php/ews/types/DaylightTime.class.php
@@ -1,0 +1,5 @@
+<?php namespace ews\types;
+
+class DaylightTime extends \ews\Object {
+  
+}

--- a/src/main/php/ews/types/Email.class.php
+++ b/src/main/php/ews/types/Email.class.php
@@ -1,0 +1,13 @@
+<?php namespace ews\types;
+
+use ews\Value;
+
+class Email extends \ews\Object {
+
+  public function __construct($address= null, $name= null, $routingType= null) {
+    parent::__construct(nameof($this));
+    $address && $this->members['Address']= Value::typed('ews.types.Address', $address);
+    $name && $this->members['Name']= Value::typed('ews.types.Name', $name);
+    $routingType && $this->members['RoutingType']= Value::typed('ews.types.RoutingType', $routingType);
+  }
+}

--- a/src/main/php/ews/types/FreeBusyViewOptions.class.php
+++ b/src/main/php/ews/types/FreeBusyViewOptions.class.php
@@ -1,0 +1,21 @@
+<?php namespace ews\types;
+
+use ews\Value;
+
+class FreeBusyViewOptions extends \ews\Object {
+  
+  public function __construct(
+    TimeWindow $timeWindow= null,
+    $mergedFreeBusyIntervalInMinutes= null,
+    RequestedView $requestedView= null
+  ) {
+    parent::__construct(nameof($this));
+    $timeWindow && $this->with($timeWindow);
+    $mergedFreeBusyIntervalInMinutes && $this->with(Value::typed(
+      'ews.types.MergedFreeBusyIntervalInMinutes',
+      $mergedFreeBusyIntervalInMinutes
+    ));
+    $requestedView && $this->with($requestedView);
+  }
+ 
+}

--- a/src/main/php/ews/types/MailboxData.class.php
+++ b/src/main/php/ews/types/MailboxData.class.php
@@ -1,0 +1,16 @@
+<?php namespace ews\types;
+
+use ews\Value;
+
+class MailboxData extends \ews\Object {
+
+  public function __construct(Email $email= null, AttendeeType $attendeeType= null, $excludeConflicts= null) {
+    parent::__construct(nameof($this));
+    $email && $this->members['Email']= $email;
+    $attendeeType && $this->members['AttendeeType']= $attendeeType;
+    null === $excludeConflicts || $this->members['ExcludeConflicts']= Value::typed(
+      'ews.types.ExcludeConflicts',
+      $excludeConflicts ? 'true' : 'false'
+    );
+  }
+}

--- a/src/main/php/ews/types/RequestedView.class.php
+++ b/src/main/php/ews/types/RequestedView.class.php
@@ -1,0 +1,20 @@
+<?php namespace ews\types;
+
+class RequestedView extends \ews\Value {
+  public static $NONE, $MERGEDONLY, $FREEBUSY, $FREEBUSYMERGED, $DETAILED, $DETAILEDMERGED;
+
+  static function __static() {
+    self::$FREEBUSY= new self('FreeBusy');
+    self::$NONE= new self('None');
+    self::$MERGEDONLY= new self('MergedOnly');
+    self::$FREEBUSY= new self('FreeBusy');
+    self::$FREEBUSYMERGED= new self('FreeBusyMerged');
+    self::$DETAILED= new self('Detailed');
+    self::$DETAILEDMERGED= new self('DetailedMerged');
+  }
+
+  public function __construct($string= null) {
+    parent::__construct(nameof($this));
+    $this->string= $string;
+  }
+}

--- a/src/main/php/ews/types/StandardTime.class.php
+++ b/src/main/php/ews/types/StandardTime.class.php
@@ -1,0 +1,5 @@
+<?php namespace ews\types;
+
+class StandardTime extends \ews\Object {
+  
+}

--- a/src/main/php/ews/types/TimeWindow.class.php
+++ b/src/main/php/ews/types/TimeWindow.class.php
@@ -1,0 +1,29 @@
+<?php namespace ews\types;
+
+use ews\Value;
+use util\Date;
+
+class TimeWindow extends \ews\Object {
+
+  /**
+   * Creates a new time window
+   * 
+   * @param  util.Date|string $start
+   * @param  util.Date|string $end
+   */
+  public function __construct($start= null, $end= null) {
+    parent::__construct(nameof($this));
+    $start && $this->with(Value::typed('ews.types.StartTime', $this->format($start)));
+    $end && $this->with(Value::typed('ews.types.EndTime', $this->format($end)));
+  }
+
+  /**
+   * Format a date
+   *
+   * @param  util.Date|string $date
+   * @return string
+   */
+  private function format($date) {
+    return $date instanceof Date ? $date->toString('Y-m-d\TH:i:s') : $date;
+  }
+}

--- a/src/main/php/ews/types/TimeZone.class.php
+++ b/src/main/php/ews/types/TimeZone.class.php
@@ -1,0 +1,5 @@
+<?php namespace ews\types;
+
+class TimeZone extends \ews\Object {
+  
+}

--- a/src/main/php/ews/types/WorkingHours.class.php
+++ b/src/main/php/ews/types/WorkingHours.class.php
@@ -1,0 +1,5 @@
+<?php namespace ews\types;
+
+class WorkingHours extends \ews\Object {
+  
+}

--- a/src/main/php/ews/types/WorkingPeriod.class.php
+++ b/src/main/php/ews/types/WorkingPeriod.class.php
@@ -1,0 +1,5 @@
+<?php namespace ews\types;
+
+class WorkingPeriod extends \ews\Object {
+  
+}

--- a/src/main/php/ews/types/WorkingPeriodArray.class.php
+++ b/src/main/php/ews/types/WorkingPeriodArray.class.php
@@ -1,0 +1,5 @@
+<?php namespace ews\types;
+
+class WorkingPeriodArray extends \ews\ListOf {
+  
+}

--- a/src/main/php/ews/xml/ParseInto.class.php
+++ b/src/main/php/ews/xml/ParseInto.class.php
@@ -8,12 +8,12 @@ use ews\Object;
 use ews\Result;
 
 class ParseInto implements ParserCallback {
-  const CHILDREN  = 0;
-  const CONTENT   = 1;
-  const MEMBERS   = 2;
-  const NAMESPACE = 3;
-  const NAME      = 0;
-  const ELEMENT   = 1;
+  const CHILDREN   = 0;
+  const CONTENT    = 1;
+  const MEMBERS    = 2;
+  const NAMESPACES = 3;
+  const NAME       = 0;
+  const ELEMENT    = 1;
 
   private static $packages;
 
@@ -50,10 +50,10 @@ class ParseInto implements ParserCallback {
     }
 
     array_unshift($this->nodes, [
-      self::CHILDREN  => [],
-      self::CONTENT   => '',
-      self::MEMBERS   => $members,
-      self::NAMESPACE => $namespaces
+      self::CHILDREN   => [],
+      self::CONTENT    => '',
+      self::MEMBERS    => $members,
+      self::NAMESPACES => $namespaces
     ]);
   }
 
@@ -81,7 +81,7 @@ class ParseInto implements ParserCallback {
       $target->with($element[self::ELEMENT], $element[self::NAME]);
     }
     $this->nodes[0][self::CHILDREN][]= [self::NAME => $name, self::ELEMENT => $target];
-    $this->namespaces= $node[self::NAMESPACE];
+    $this->namespaces= $node[self::NAMESPACES];
   }
 
   public function onCData($parser, $cdata) {


### PR DESCRIPTION
This PR adds all the types necessary for performing a [GetUserAvailability](https://msdn.microsoft.com/en-us/library/office/aa563800(v=exchg.150).aspx) request.

### Example
```php
use util\cmd\Console;
use ews\ExchangeService;
use ews\messages\GetUserAvailabilityRequest;
use ews\types\AttendeeType;
use ews\types\MailboxData;
use ews\types\Email;
use ews\types\FreeBusyViewOptions;
use ews\types\TimeWindow;
use ews\types\RequestedView;
use util\Date;

$mailboxes= [];
foreach (array_slice($argv, 1) as $email) {
  $mailboxes[]= new MailboxData(new Email($email), AttendeeType::$REQUIRED, false);
}

$request= new GetUserAvailabilityRequest($mailboxes, new FreeBusyViewOptions(
  new TimeWindow(new Date('2017-01-23 09:00'), new Date('2017-01-23 18:00')),
  30,
  RequestedView::$FREEBUSY
));

$ews= new ExchangeService(...);
Console::writeLine($ews->invoke($request));

